### PR TITLE
issue #104 Refactor git unit tests

### DIFF
--- a/Assignment2/gitfunctions.py
+++ b/Assignment2/gitfunctions.py
@@ -1,19 +1,19 @@
 from git import Repo
 import shutil
 import os
+from server import tempDir
 # path to where this class will create the directory to pull the project into
-gitDir = "./temp-git-dir/"
 
 class GitRepo:
     """ Creates a repo object and checks out the given branch (remember the branch name is different if you have it locally)
-        This will create it in your local filesystem currently at gitDir = "./temp-git-dir/"
+        This will create it in your local filesystem currently at tempDir = "./temp-git-dir/"
     """
-    def __init__(self, branchName) -> None:
-        if os.path.exists(gitDir):
-            shutil.rmtree(gitDir)
-        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", gitDir, branch=branchName)
+    def __init__(self, directory, branchName) -> None:
+        if os.path.exists(directory):
+            shutil.rmtree(directory)
+        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", directory, branch=branchName)
         print("Cloned repo from remote")
-        self.repoLocalPath = gitDir
+        self.repoLocalPath = directory
         pullinfo = self.gitPull()
         print(pullinfo)
         #self.checkoutBranch("master")          #How to checkout a local branch  
@@ -37,17 +37,17 @@ class GitRepo:
             print("The repo contains stuff!")
             return True
 
-    def forceClone(self, branchName):
+    def forceClone(self, directory, branchName):
         """Force a git clone (for example if you've deleted files, which git won't reset with a pull)
 
         Args:
             branchName (String): name of the branch you want to clone
         """
         try:
-            shutil.rmtree(gitDir)
+            shutil.rmtree(directory)
         except OSError as e:
-            print("Error: %s : %s" % (gitDir, e.strerror))
-        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", gitDir, branch=branchName)
+            print("Error: %s : %s" % (directory, e.strerror))
+        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", directory, branch=branchName)
         print("Cloned repo from remote")
 
     def gitPull(self):
@@ -82,5 +82,5 @@ class GitRepo:
             print(str(e))
 
 if __name__=='__main__':
-    gitrepo = GitRepo("master")
+    gitrepo = GitRepo(tempDir, "master")
 

--- a/Assignment2/gitfunctions.py
+++ b/Assignment2/gitfunctions.py
@@ -1,5 +1,6 @@
 from git import Repo
 import shutil
+import os
 # path to where this class will create the directory to pull the project into
 gitDir = "./temp-git-dir/"
 
@@ -8,16 +9,10 @@ class GitRepo:
         This will create it in your local filesystem currently at gitDir = "./temp-git-dir/"
     """
     def __init__(self, branchName) -> None:
-        try:
-            self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", gitDir, branch=branchName)
-            print("Cloned repo from remote")
-        except Exception as e:
-            print("Git testing repo found at:", gitDir)
-            if(str(e)[0:40] == "Cmd('git') failed due to: exit code(128)"):
-                #you already have a directory called {gitDir="./temp-git-dir/"} so we'll use that one
-                self.repo = Repo(gitDir)
-            else:
-                raise
+        if os.path.exists(gitDir):
+            shutil.rmtree(gitDir)
+        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", gitDir, branch=branchName)
+        print("Cloned repo from remote")
         self.repoLocalPath = gitDir
         pullinfo = self.gitPull()
         print(pullinfo)

--- a/Assignment2/gitfunctions.py
+++ b/Assignment2/gitfunctions.py
@@ -1,6 +1,5 @@
-import os
 from git import Repo
-
+import shutil
 # path to where this class will create the directory to pull the project into
 gitDir = "./temp-git-dir/"
 
@@ -20,23 +19,59 @@ class GitRepo:
             else:
                 raise
         self.repoLocalPath = gitDir
-        pullinfo = self.repo.git.pull()     #call git pull directly and read from stdout
+        pullinfo = self.gitPull()
         print(pullinfo)
         #self.checkoutBranch("master")          #How to checkout a local branch  
         #self.checkoutBranch("origin/issue1")   #How to checkout a remote branch
 
-        self.checkRepo()
+        self.checkRepoNotBare()
         self.repo.config_reader()             # get a config reader for read-only access
         with self.repo.config_writer():       # get a config writer to change configuration
             pass                         # call release() to be sure changes are written and locks are released
 
-    def checkRepo(self):
+    def checkRepoNotBare(self):
         """Checks to make sure the pulled repo isn't empty
+
+        Returns:
+            [bool]: False if repo is empty, True otherwise
         """
         if(self.repo.bare):
             print("Repo is bare :(")
+            return False
         else:
             print("The repo contains stuff!")
+            return True
+
+    def forceClone(self, branchName):
+        """Force a git clone (for example if you've deleted files, which git won't reset with a pull)
+
+        Args:
+            branchName (String): name of the branch you want to clone
+        """
+        try:
+            shutil.rmtree(gitDir)
+        except OSError as e:
+            print("Error: %s : %s" % (gitDir, e.strerror))
+        self.repo = Repo.clone_from("https://github.com/DD2480-Team/DD2480.git", gitDir, branch=branchName)
+        print("Cloned repo from remote")
+
+    def gitPull(self):
+        """Perform a git pull, in repo and on branch ALREADY SPECIFIED
+
+        Returns:
+            [String]: stdout from the git pull
+        """
+        pullinfo = self.repo.git.pull()     #call git pull directly and read from stdout
+        return pullinfo
+
+    def gitStatus(self):
+        """Perform a git status
+
+        Returns:
+            [String]: stdout from the git status
+        """
+        statusInfo = self.repo.git.status()     #call git pull directly and read from stdout
+        return statusInfo
 
     def checkoutBranch(self, branchName):
         """ Check out the given branch from git 

--- a/Assignment2/server.py
+++ b/Assignment2/server.py
@@ -15,6 +15,7 @@ app = Flask(__name__)
 
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///C:\\sqlite\\test.db"
 app.config["CORS_HEADERS"] = "Content-Type"
+app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
 db = SQLAlchemy(app)
 

--- a/Assignment2/server.py
+++ b/Assignment2/server.py
@@ -40,8 +40,8 @@ app.config["MAIL_USE_TLS"] = False
 app.config["MAIL_USE_SSL"] = True
 mail = Mail(app)
 
-defaultBranch = "issue-68-listing-past-builds"
-allowTests = False
+defaultBranch = "master"
+allowTests = True
 
 
 @app.route("/")
@@ -140,4 +140,4 @@ def get_history():
 
 if __name__ == "__main__":
     app.secret_key = "super secret key"
-    app.run(debug=True, port=4567)
+    app.run(debug=False, port=4567)

--- a/Assignment2/server.py
+++ b/Assignment2/server.py
@@ -40,7 +40,8 @@ app.config["MAIL_USE_TLS"] = False
 app.config["MAIL_USE_SSL"] = True
 mail = Mail(app)
 
-defaultBranch = "master"
+tempDir = "./temp-git-dir/"
+currentBranch = "master"
 allowTests = True
 
 
@@ -99,13 +100,14 @@ def webhook_message():
             info = json.dumps(request.json)
             data = json.loads(info)
             newBuild = save_json_to_build(data)
-            gitRepo = gitfunctions.GitRepo(newBuild.branch)
+            currentBranch = newBuild.branch
+            gitRepo = gitfunctions.GitRepo(tempDir, currentBranch)
             syntaxCheck = build.SyntaxCheck(
-                gitRepo.repoLocalPath + "Assignment2/server.py"
+                tempDir + "Assignment2/server.py"
             )
             if allowTests:
                 testing = test.Test(
-                    gitRepo.repoLocalPath + "Assignment2/test_server.py"
+                    tempDir + "Assignment2/test_server.py"
                 )
             update_build_with_syntax_check(newBuild, syntaxCheck.result)
             data = {"build_result": syntaxCheck.result, "error": ""}

--- a/Assignment2/server.py
+++ b/Assignment2/server.py
@@ -42,7 +42,7 @@ mail = Mail(app)
 
 tempDir = "./temp-git-dir/"
 currentBranch = "master"
-allowTests = True
+allowTests = False
 
 
 @app.route("/")

--- a/Assignment2/test_server.py
+++ b/Assignment2/test_server.py
@@ -1,10 +1,11 @@
 import pytest
-from server import webhook_message, app
+from server import webhook_message, app, currentBranch, tempDir
 from gitfunctions import GitRepo
 import json
 import os
 
-testBranch = "refactor-git-unit-tests"
+testBranch = "git-unit-tests"
+testDir = "./test-git-dir/"
 
 @pytest.fixture
 def client():
@@ -47,7 +48,8 @@ def test_git_pull_not_empty():
     and then asserts that it is not empty
     """
     repo = GitRepo(testBranch)
-    assert(repo.checkRepoNotBare() ==  True)
+    repo_is_not_bare = repo.checkRepoNotBare()
+    assert(repo_is_not_bare)
 
 def test_git_pull_removed_file():
     """
@@ -55,11 +57,9 @@ def test_git_pull_removed_file():
     then REMOVES the server file and
     checks git status to see git is running and responds correctly
     """
-    repo = GitRepo(testBranch)
-    repo.forceClone(testBranch) #don't allow a local version of repo
+    repo = GitRepo(testDir, testBranch)
+    repo.forceClone(testDir, testBranch) #don't allow a local version of repo
     os.remove(repo.repoLocalPath + "Assignment2/server.py")
     gitStatus = repo.gitStatus()
-
-    repo.forceClone(testBranch) #reset local files just in case someone runs this case in another case
-    
+    repo.forceClone(testDir, testBranch) #reset local files just in case someone runs this case in another case
     assert(gitStatus.find("deleted:    Assignment2/server.py") !=  -1)

--- a/Assignment2/test_server.py
+++ b/Assignment2/test_server.py
@@ -4,7 +4,7 @@ from gitfunctions import GitRepo
 import json
 import os
 
-testBranch = "push_for_testing"
+testBranch = "refactor-git-unit-tests"
 
 @pytest.fixture
 def client():
@@ -29,16 +29,16 @@ def test_webhook_message(client):
     Args:
         client (defined above): an interface to a specfically configured app instance
 
-    Test result: Pass if status code being returned is 201
+    Test result: Pass if status code being returned is 404, as the endpoint doesn't exists
     """
 
-    url = "/github"
+    url = "/non_existent_endpoint"
     with open("test_success_body.json") as f:
         data = json.load(f)
     header = {"X-Github-Event": "push"}
 
     rv = client.post(url, json=data, headers=header)
-    assert rv.status_code == 201
+    assert rv.status_code == 404
 
 def test_git_pull_not_empty():
     """

--- a/Assignment2/test_server.py
+++ b/Assignment2/test_server.py
@@ -47,7 +47,7 @@ def test_git_pull_not_empty():
     or if you already have the repo, just a git pull
     and then asserts that it is not empty
     """
-    repo = GitRepo(testBranch)
+    repo = GitRepo(testDir, testBranch)
     repo_is_not_bare = repo.checkRepoNotBare()
     assert(repo_is_not_bare)
 

--- a/Assignment2/test_server.py
+++ b/Assignment2/test_server.py
@@ -1,7 +1,10 @@
 import pytest
 from server import webhook_message, app
+from gitfunctions import GitRepo
 import json
+import os
 
+testBranch = "push_for_testing"
 
 @pytest.fixture
 def client():
@@ -36,3 +39,27 @@ def test_webhook_message(client):
 
     rv = client.post(url, json=data, headers=header)
     assert rv.status_code == 201
+
+def test_git_pull_not_empty():
+    """
+    Creates a git object, performs a git clone,
+    or if you already have the repo, just a git pull
+    and then asserts that it is not empty
+    """
+    repo = GitRepo(testBranch)
+    assert(repo.checkRepoNotBare() ==  True)
+
+def test_git_pull_removed_file():
+    """
+    Creates a git object, forces a git clone,
+    then REMOVES the server file and
+    checks git status to see git is running and responds correctly
+    """
+    repo = GitRepo(testBranch)
+    repo.forceClone(testBranch) #don't allow a local version of repo
+    os.remove(repo.repoLocalPath + "Assignment2/server.py")
+    gitStatus = repo.gitStatus()
+
+    repo.forceClone(testBranch) #reset local files just in case someone runs this case in another case
+    
+    assert(gitStatus.find("deleted:    Assignment2/server.py") !=  -1)


### PR DESCRIPTION
This branch is an attempt at refactoring the gitfunctions to be as simple as possible while meeting  the needs of the server.

Instead of checking if the temporary directory already exists, the GitRepo initialization begins with deleting the temp directory if it exists. 

While this may change other functionality (that I don't think we really use), I think for the purpose of the project, this is the simplest way of managing the cloned repo - the point of the server is to simply pull,  compile, and test the code in a specific branch, not to be able to handle switching branches or pushing code, or merging etc. 

Another change was adding "directory" as an input to GitRepo, so tests can be cloned into a temporary testing  repo, and not overwrite the temp-git-dir which the server should be testing. tempDir is now a variable in server.py. 

Side note: when testing, you need to send a webhook cloning the branch you are currently working on -  preferably as recent as possible - as the tests being run are on the branch you are cloning. 

closes #104 